### PR TITLE
Add support for sending ETH and ERC20 tokens

### DIFF
--- a/contents/plasmo.tsx
+++ b/contents/plasmo.tsx
@@ -26,5 +26,10 @@ export const getInlineAnchor: PlasmoGetInlineAnchor = async () =>
     "div[data-testid='sidebarColumn'] > div > div:nth-child(2) > div > div > div > div:nth-child(2)"
   );
 // document.querySelector("div[id='lg']");
+// export const getRootContainer = () => {
+//   let div = document.createElement('div');
+//   div.classList.add('fffff');
+//   return div;
+// };
 
 export default Popup;

--- a/globals.css
+++ b/globals.css
@@ -78,3 +78,7 @@
 div, p, h1, h2, h3, ul, li {
   box-sizing: border-box;
 }
+
+#plasmo-shadow-container {
+  z-index: 1 !important;
+}

--- a/popup/SendToken/index.tsx
+++ b/popup/SendToken/index.tsx
@@ -12,8 +12,14 @@ function SendToken(props: {}) {
     navigate(-1);
   }, []);
   const [searchParams] = useSearchParams();
-  const { ethBalance, usdtBalance, getXWalletAddress, appendRecord, sendETH } =
-    useContext(XWalletProviderContext);
+  const {
+    ethBalance,
+    usdtBalance,
+    getXWalletAddress,
+    appendRecord,
+    sendETH,
+    sendERC20,
+  } = useContext(XWalletProviderContext);
 
   const [balance, setBalance] = useState(ethBalance);
   const [amount, setAmount] = useState('');
@@ -65,7 +71,14 @@ function SendToken(props: {}) {
       'To',
       targetAddress
     );
-    await sendETH(targetAddress, amount);
+    if ('matic' == selectedCurrency) await sendETH(targetAddress, amount);
+    else
+      await sendERC20(
+        '0x4aAeB0c6523e7aa5Adc77EAD9b031ccdEA9cB1c3',
+        targetAddress,
+        amount,
+        18
+      );
     appendRecord({
       timestamp: new Date().toString(),
       toTwitter: targetHandle,

--- a/popup/SendToken/index.tsx
+++ b/popup/SendToken/index.tsx
@@ -12,7 +12,7 @@ function SendToken(props: {}) {
     navigate(-1);
   }, []);
   const [searchParams] = useSearchParams();
-  const { ethBalance, usdtBalance, getXWalletAddress, appendRecord } =
+  const { ethBalance, usdtBalance, getXWalletAddress, appendRecord, sendETH } =
     useContext(XWalletProviderContext);
 
   const [balance, setBalance] = useState(ethBalance);
@@ -56,7 +56,7 @@ function SendToken(props: {}) {
     changeBalance(currency);
   };
 
-  const handleSendToken = () => {
+  const handleSendToken = async () => {
     console.log(
       'Send',
       selectedCurrency,
@@ -65,6 +65,7 @@ function SendToken(props: {}) {
       'To',
       targetAddress
     );
+    await sendETH(targetAddress, amount);
     appendRecord({
       timestamp: new Date().toString(),
       toTwitter: targetHandle,
@@ -79,18 +80,23 @@ function SendToken(props: {}) {
   const handleTwitterBlur = async () => {
     const twitterUsername = twitterRef.current?.value;
     console.log('Twitter Username', twitterUsername);
+    if (/^0x[0-9a-fA-F]{40}$/.test(twitterUsername)) {
+      setTargetHandle(twitterUsername);
+      setTargetAddress(twitterUsername);
+    } else {
+      if (twitterUsername) {
+        // 调用后台接口获取目标地址
 
-    if (twitterUsername) {
-      // 调用后台接口获取目标地址
-      const data = await getXWalletAddress(twitterUsername);
-      console.log('Target Address', data.account_address);
-      setTargetAddress(data.account_address);
+        const data = await getXWalletAddress(twitterUsername);
+        console.log('Target Address', data.account_address);
+        setTargetAddress(data.account_address);
 
-      let handle = twitterUsername; // if address, shorten
-      if (handle.startsWith('0x') && handle.length > 16) {
-        handle = addressFormat(handle);
+        let handle = twitterUsername; // if address, shorten
+        if (handle.startsWith('0x') && handle.length > 16) {
+          handle = addressFormat(handle);
+        }
+        setTargetHandle(handle);
       }
-      setTargetHandle(handle);
     }
   };
 

--- a/popup/components/HistoryBox/index.tsx
+++ b/popup/components/HistoryBox/index.tsx
@@ -27,7 +27,7 @@ function HistoryBox() {
 
   return (
     <div className="bg-[#E9E9E9] text-center px-5 py-4 h-[170px] relative rounded-b-2xl overflow-x-hidden overflow-y-scroll ">
-      { !txRecords || txRecords.length === 0 ? (
+      {!txRecords || txRecords.length === 0 ? (
         <div
           className={cn(
             'absolute bottom-2 left-4',
@@ -39,7 +39,7 @@ function HistoryBox() {
           X-wallet support
         </div>
       ) : (
-        <div className='overflow-hidden'>
+        <div className="overflow-hidden">
           {txRecords.map((item) => (
             <>
               <div className={cn('text-left text-[#979797] mb-3')}>
@@ -52,11 +52,7 @@ function HistoryBox() {
                   'flex justify-between items-center',
                   'h-10 w-[100%] px-6 py-2 mb-3 rounded-2xl bg-white'
                 )}
-                onClick={(i) =>
-                  toTransactionDetail(
-                    '0x9628815ffa0a91bb4ee0e5b5dc25b84c1c0ebd1d1b76975fb6961397f8bac1f3'
-                  )
-                }
+                onClick={(i) => toTransactionDetail(item.hash)}
               >
                 <span>{item.toTwitter}</span>
                 <span
@@ -65,10 +61,8 @@ function HistoryBox() {
                     'text-[#B82929]': !item.amount,
                   })}
                 >
-                  {item.amount ? 
-                    isShowMoney ? item.amount : '*** ' 
-                    : ' '} 
-                  {item.currency.toUpperCase()}           
+                  {item.amount ? (isShowMoney ? item.amount : '*** ') : ' '}
+                  {item.currency.toUpperCase()}
                 </span>
               </div>
             </>

--- a/popup/context/XWalletProvider.tsx
+++ b/popup/context/XWalletProvider.tsx
@@ -13,6 +13,7 @@ import {
   http,
   parseAbi,
   parseEther,
+  parseUnits,
 } from 'viem';
 import { polygonMumbai } from 'viem/chains';
 import { NFT_Contract_Abi } from '~contractAbi.js';
@@ -211,14 +212,15 @@ export function XWalletProvider({ children }) {
     async (
       tokenAddress: `0x${string}`,
       toAddress: `0x${string}`,
-      value: string
+      value: string,
+      dec: number
     ) => {
       const { hash } = await ecdsaProvider.sendUserOperation({
         target: tokenAddress,
         data: encodeFunctionData({
-          abi: TRANSFER_FUNC_ABI,
+          abi: ERC20Abi,
           functionName: 'transfer',
-          args: [toAddress, parseEther(value)],
+          args: [toAddress, parseUnits(value, dec)],
         }),
       });
       console.log('Send to', toAddress, 'ETH', value, 'hash', hash);

--- a/popup/index.css
+++ b/popup/index.css
@@ -15,3 +15,5 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+


### PR DESCRIPTION
This pull request adds the ability to send both ETH and ERC20 tokens through the XWalletProviderContext. It includes the implementation of the sendETH and sendERC20 functions, as well as updates to the SendToken component to allow for selecting the currency to send. Additionally, the txRecords state has been updated to include the currency of each transaction.

No issue number referenced.